### PR TITLE
Check to make sure zillow result is returned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,7 @@ gem 'httpclient'
 gem 'nokogiri'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       tzinfo (~> 1.1)
     arel (7.1.2)
     builder (3.2.2)
-    byebug (9.0.5)
+    coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -86,6 +86,10 @@ GEM
       pkg-config (~> 1.1.7)
     pg (0.18.4)
     pkg-config (1.1.7)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     puma (3.6.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -124,6 +128,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    slop (3.6.0)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
       listen (>= 2.7, < 4.0)
@@ -158,7 +163,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   coffee-rails (~> 4.2)
   geocoder
   gmaps4rails
@@ -168,6 +172,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   nokogiri
   pg
+  pry
   puma (~> 3.0)
   rails (~> 5.0.0)
   sass-rails (~> 5.0)

--- a/lib/pretty_navicamls/listing_builder.rb
+++ b/lib/pretty_navicamls/listing_builder.rb
@@ -19,7 +19,6 @@ module PrettyNavicamls
 
     def property_attributes
       listing_html.css("#expanded-label").each_with_object({}) do |element, hash|
-        begin
         attribute = element.text.parameterize.underscore
         value = element.next
                         .text
@@ -28,9 +27,6 @@ module PrettyNavicamls
                         .last
 
         hash[attribute.to_sym] = value
-        rescue => e
-          byebug
-        end
       end
     end
 
@@ -71,8 +67,11 @@ module PrettyNavicamls
     def zillow_url
       @zillow_url ||= begin
         return nil unless defined?(ZILLOW_API_URL)
-        response = ::HTTPClient.get("#{ZILLOW_API_URL}&address=#{address.gsub("#{zip_code}", "")}&citystatezip=#{zip_code}")
+        response = ::HTTPClient.get("#{ZILLOW_API_URL}&address=#{address.gsub("#{zip_code}", "").strip}&citystatezip=#{zip_code}")
         home_details = ::Nokogiri::XML.parse(response.body)
+
+        return nil if home_details.at("homedetails").blank?
+
         home_details.at("homedetails").text
       end
     end


### PR DESCRIPTION
This will prevent failures parsing a Navica listing when trying to call out for a zillow result and not finding the home.
