### PR TITLE
Handle parsed attributes that are invalid

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -9,8 +9,14 @@ class ListingsController < ::ApplicationController
 
   def create
     fail ::PrettyNavicamls::Error::UnsupportedURL unless supported_url?
-    parsed_listings_count = ::PrettyNavicamls::Parser.parse_listings(navicamls_listings_url)
-    flash[:notice] = "Successfully added #{parsed_listings_count} homes from #{navicamls_listings_url}"
+    
+    parser_results = ::PrettyNavicamls::Parser.parse_listings(navicamls_listings_url)
+    flash[:notice] = "Successfully added #{parser_results[:successful]} homes from #{navicamls_listings_url}"
+
+    if parser_results[:invalid_attributes].present?
+      flash[:warning] = "Invalid Attributes found: #{parser_results[:invalid_attributes].uniq.join(", ")}"
+    end
+
     redirect_to "/"
   rescue ::PrettyNavicamls::Error::UnsupportedURL => e
     flash[:error] = "#{e.message}: #{navicamls_listings_url}"

--- a/lib/pretty_navicamls/listing_builder.rb
+++ b/lib/pretty_navicamls/listing_builder.rb
@@ -2,10 +2,11 @@ require "httpclient"
 
 module PrettyNavicamls
   class ListingBuilder
-    attr_reader :listing_html, :navica_url
+    attr_reader :listing_html, :navica_url, :invalid_attributes
 
     def initialize(html, url)
       @listing_html = html
+      @invalid_attributes = []
       @navica_url = url
     end
 
@@ -20,6 +21,12 @@ module PrettyNavicamls
     def property_attributes
       listing_html.css("#expanded-label").each_with_object({}) do |element, hash|
         attribute = element.text.parameterize.underscore
+
+        if ::Listing.column_names.exclude?(attribute)
+          @invalid_attributes << attribute
+          next
+        end
+
         value = element.next
                         .text
                         .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')

--- a/lib/pretty_navicamls/parser.rb
+++ b/lib/pretty_navicamls/parser.rb
@@ -26,14 +26,15 @@ module PrettyNavicamls
         div if has_mls_number?(div) && has_details_container?(div)
       end
 
+      invalid_attributes = []
       listings.each do |listing_html|
         parsed_listing = ::PrettyNavicamls::ListingBuilder.new(listing_html, navica_url)
         listing = ::Listing.by_mls_number(parsed_listing.mls_number).first_or_create
         listing.update_attributes(parsed_listing.attributes)
+        invalid_attributes << parsed_listing.invalid_attributes
       end
 
-      # Just return the number of successful listings added
-      listings.count
+      { :successful => listings.count, :invalid_attributes => invalid_attributes }
     end
 
   private


### PR DESCRIPTION
Handles the case where a listing may have more attributes that are available on the model. 

Saves them and flashes a warning message with the attributes for option to add later.
