### PR TITLE
Use paperclip to manage photos and thumbnails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'geocoder'
 gem 'gmaps4rails'
 gem 'httpclient'
 gem 'nokogiri'
+gem "paperclip", "~> 5.0.0"
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,10 @@ GEM
     capistrano3-puma (1.2.1)
       capistrano (~> 3.0)
       puma (>= 2.6)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -98,6 +102,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
@@ -108,6 +113,12 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    paperclip (5.0.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (~> 0.3.0)
     pg (0.18.4)
     pkg-config (1.1.7)
     pry (0.10.4)
@@ -203,6 +214,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   nokogiri
+  paperclip (~> 5.0.0)
   pg
   pry
   puma (~> 3.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -40,6 +40,11 @@
   width: 100%;
 }
 
+a:hover {
+  color: blue;
+  text-decoration:underline;
+}
+
 .warning {
   color: #c09853;
   background-color: #fcf8e3;

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -48,6 +48,7 @@ private
 
   def generate_listings_map_hash
     ::Gmaps4rails.build_markers(@listings) do |listing, marker|
+      status_color = ::Listing::PIN_COLORS_FROM_STATUS[listing.status]
       marker.lat(listing.latitude)
       marker.lng(listing.longitude)
       marker.picture({
@@ -57,7 +58,7 @@ private
         :scaledWidth => "32", # Scaled width is half of the retina resolution; optional
         :scaledHeight => "32", # Scaled width is half of the retina resolution; optional
       })
-      marker.title("#{listing.mls_number} | #{listing.address}")
+      marker.title("[ <span style='color:#{status_color}'>#{listing.mls_number}</span> ] #{listing.address}")
       marker.infowindow render_to_string(:partial => "infowindow.html.erb", :locals => { :listing => listing}).gsub(/\n/, '')
     end
   end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,11 +1,14 @@
 class Listing < ActiveRecord::Base
   geocoded_by :address
+  has_attached_file :cover_photo, :styles => { :thumb => "165x220>" }, :validate_media_type => false
 
   MARKER_URL = "http://maps.google.com/mapfiles/ms/icons/".freeze
 
   ##
   # Validations
   #
+  # # Validate content type
+  validates_attachment_content_type :cover_photo, content_type: /\Aimage/
   validates :mls_number, :presence => true
 
   ##
@@ -38,6 +41,11 @@ class Listing < ActiveRecord::Base
 
   def constructor
     self.status = ::Listing.statuses[:created]
+  end
+
+  def cover_photo_remote_url=(url_value)
+    self.cover_photo = URI.parse(url_value)
+    super
   end
 
   def pin_url

--- a/app/views/listings/_infowindow.html.erb
+++ b/app/views/listings/_infowindow.html.erb
@@ -1,7 +1,7 @@
 <div>
   <strong><%= listing.mls_number %></strong>
   <br />
-  <img height='165' width='220' src='<%= listing.picture_url %>'></img>
+  <%= image_tag listing.cover_photo.url(:thumb) %>
   <br/>
   <%= number_to_currency(listing.list_price) %>
   <% if listing.list_price_change_amount %>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -1,5 +1,5 @@
 <center>
-  <%= image_tag(@listing.picture_url) %>
+  <%= image_tag @listing.cover_photo.url %>
 </center>
 <br />
 <% ::Listing.statuses.each do |status, val|  %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ module PrettyNavicamls
 
     config.eager_load = true
     config.autoload_paths += %W(#{config.root}/lib)
-    puts config.autoload_paths
     config.eager_load_paths += %W(#{config.root}/lib/pretty_navicamls)
   end
 end

--- a/db/migrate/20161002211015_add_paperclip_fields.rb
+++ b/db/migrate/20161002211015_add_paperclip_fields.rb
@@ -1,0 +1,8 @@
+class AddPaperclipFields < ActiveRecord::Migration[5.0]
+  def change
+    change_table :listings do |t|
+      t.attachment :cover_photo
+      t.rename :picture_url, :cover_photo_remote_url 
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001184810) do
+ActiveRecord::Schema.define(version: 20161002211015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20161001184810) do
     t.float    "apx_acreage"
     t.integer  "mls_number"
     t.integer  "apx_total_sqft"
-    t.string   "picture_url"
+    t.string   "cover_photo_remote_url"
     t.integer  "status"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
@@ -74,6 +74,10 @@ ActiveRecord::Schema.define(version: 20161001184810) do
     t.string   "navica_url"
     t.string   "zillow_url"
     t.float    "list_price_change_amount"
+    t.string   "cover_photo_file_name"
+    t.string   "cover_photo_content_type"
+    t.integer  "cover_photo_file_size"
+    t.datetime "cover_photo_updated_at"
     t.index ["mls_number"], name: "index_listings_on_mls_number", unique: true, using: :btree
   end
 

--- a/lib/pretty_navicamls/listing_builder.rb
+++ b/lib/pretty_navicamls/listing_builder.rb
@@ -42,7 +42,7 @@ module PrettyNavicamls
         :address => address,
         :list_price => list_price,
         :navica_url => navica_url,
-        :picture_url => picture_url,
+        :cover_photo_remote_url => cover_photo_remote_url,
         :zillow_url => zillow_url
       }
     end
@@ -64,8 +64,8 @@ module PrettyNavicamls
       end
     end
 
-    def picture_url
-      @picture_url ||= begin
+    def cover_photo_remote_url
+      @cover_photo_remote_url ||= begin
         pic_path = listing_html.at("img[class=photo-expanded]")["src"]
         "http://www.navicamls.net/displays/#{pic_path}"
       end


### PR DESCRIPTION
Uses `paperclip` gem to manage attachments for the homes cover photo and thumbnails. Makes for quicker, easier loading of the map previews and the show page.
