### PR TITLE
increment independent of json_array loop

### DIFF
--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -60,9 +60,11 @@
 
     var markers = handler.addMarkers(listings_array);
 
+    var incrementer = 0;
     _.each(json_array, function(listings_json, status){
       _.each(listings_json, function(json, index){
-        json.marker = markers[index];
+        json.marker = markers[incrementer];
+        incrementer++;
       });
     });
 


### PR DESCRIPTION
Markers were being created by the `index` when looping through the listings_json. But with the addition of the status types, that index was reset because of the added nested loop.

This just creates a simple increment to handle with the same logic that was previously used
